### PR TITLE
Export a default so es6 consumers can use import config from '@bedrockio/config' syntax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,3 +99,10 @@ export function getAllPublic(onlyParsed = false): { [key: string]: string } {
 export function has(variable: string): boolean {
   return process.env[variable] !== undefined || !!parsed.get(variable);
 }
+
+export default {
+  get,
+  getAll,
+  getAllPublic,
+  has,
+}


### PR DESCRIPTION
Currently, consumers either need to do
`import { get } from '@bedrockio/config'` <- "get" is too generic
`import * as config from '@bedrockio/config'` <- namespace import

This PR will support the above, but also allow
`import config from '@bedrockio/config'` <- default import